### PR TITLE
Make the reset button white

### DIFF
--- a/SwiftTweaks/TweaksCollectionsListViewController.swift
+++ b/SwiftTweaks/TweaksCollectionsListViewController.swift
@@ -51,7 +51,7 @@ internal final class TweaksCollectionsListViewController: UIViewController {
 		view.addSubview(tableView)
 
 		let resetButton = UIBarButtonItem(title: "Reset All", style: .plain, target: self, action: #selector(self.resetStore))
-		resetButton.tintColor = AppTheme.Colors.controlDestructive
+		resetButton.tintColor = UIColor.white
 		navigationItem.rightBarButtonItem = resetButton
 
 		toolbarItems = [


### PR DESCRIPTION
This isn't the "right" way to do things, at least in the original SwiftTweaks, but with our blue header bar, the red Reset All button is terrible. Request from Mike G.